### PR TITLE
[GVN-345]fix dropdown styling

### DIFF
--- a/app/src/App.less
+++ b/app/src/App.less
@@ -657,6 +657,10 @@ p,
   }
 }
 
+#rc_select_0_list + .rc-virtual-list {
+  width: 100%;
+}
+
 /* Withdraw and restake buttons */
 .withdraw-btn {
   background: @light-green-1 !important;


### PR DESCRIPTION
- [x] fix `Explorer` dropdown styling

<details>
<summary>Click to see current mobile button</summary>
<img width="400" src="https://user-images.githubusercontent.com/68657634/160950451-33b1bdd2-8452-459a-97b5-4e2b2b27112a.png">
</details>

<details>
<summary>Click to see current desktop button</summary>
<img width="600" src="https://user-images.githubusercontent.com/68657634/160950457-7280963e-f91b-4524-acd0-a303518ed58d.png">
</details>

<details>
<summary>Click to see updated mobile button</summary>
<img width="400" src="https://user-images.githubusercontent.com/68657634/160950445-4901c0dc-d7c4-4417-99df-69e448631c46.png">
</details>

<details>
<summary>Click to see updated desktop button</summary>
<img width="600" src="https://user-images.githubusercontent.com/68657634/160950468-1393b035-cf13-4e89-b0cc-240b008458ef.png">
</details>




