### PR TITLE
Fix "mint max votes" test

### DIFF
--- a/tests/airdrop-staking.ts
+++ b/tests/airdrop-staking.ts
@@ -678,7 +678,7 @@ describe("airdrop-staking", () => {
 
     const updatedVault = await voteToken.getAccountInfo(govVault);
 
-    assert.equal(updatedVault.amount.toNumber(), 10_000_000_000);
+    assert.equal(updatedVault.amount.toNumber(), 45_652_173_913);
   });
 
   it("user cannot mint extra votes", async () => {


### PR DESCRIPTION
This fixes the test failure that prevented the devnet deployment of the latest commit, which was causing people to see panics because they weren't getting the latest bug fixes.

Since votes are based on shares instead of tokens now, the calculation is different and you can get a different number of votes. I calculated the number of votes a user should have after the sequence of events in the anchor tests:

> after "user claims airdrop" adds 4_200_000_000 tokens to user
> 42_000_000_000
> 
> after "user unbonds stake" removes 4_199_999_999 tokens from user
> 10
> 
> after "user cancels unbonding" adds back 4_199_999_999 tokens to user
> 42_000_000_000
> 
> after "user unbonds again" removes 4_199_999_999 tokens from user
> 10
> 
> after "user restakes" adds back 4_199_999_999 tokens to user
> 42_000_000_000
> 
> after "distribute reward" adds 5_000_000_000 tokens to vault
> 42_000_000_000 shares and 4_200_000_000 tokens becomes 42_000_000_000 shares and 9_200_000_000 tokens, still has 42_000_000_000 shares so...
> 42_000_000_000
> 
> after "distribute award" adds 800_000_000 tokens to user at exchange rate of 42_000_000_000/9_200_000_000...
> 42_000_000_000 + 800_000_000 * (42_000_000_000/9_200_000_000)
> **45_652_173_913**

Using my calculated value, the test passes.

Fixing this test was a pain because each test depends on state from the previous test. I had to understand all of the code in every test before I could figure out this test. In the future, it would be better to make each test independent and not share state with other tests. There can be shared setup methods that generate unique accounts for each time they are run, and each test can individually call only the setup it needs. I didn't work on this here though because I just needed to fix the test asap.