### PR TITLE
GVN-289 Do not abbreviate number under 100k

### DIFF
--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -72,7 +72,7 @@ export const abbreviateNumber = (number: number, precision: number) => {
     scaled = number / scale;
   }
 
-  return scaled.toFixed(precision) + suffix;
+  return number < 100000 ? new Intl.NumberFormat().format(Math.floor(number)) : scaled.toFixed(precision) + suffix;
 };
 
 export const formatUSD = new Intl.NumberFormat("en-US", {

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -72,7 +72,9 @@ export const abbreviateNumber = (number: number, precision: number) => {
     scaled = number / scale;
   }
 
-  return number < 100000 ? new Intl.NumberFormat().format(Math.floor(number)) : scaled.toFixed(precision) + suffix;
+  return number < 100000
+    ? new Intl.NumberFormat().format(Math.floor(number))
+    : scaled.toFixed(precision) + suffix;
 };
 
 export const formatUSD = new Intl.NumberFormat("en-US", {


### PR DESCRIPTION
Return `Math.floor(number)` under 100k