### PR TITLE
staking: export internal spl governance program id

### DIFF
--- a/programs/staking/src/lib.rs
+++ b/programs/staking/src/lib.rs
@@ -92,6 +92,12 @@ mod error {
     }
 }
 
+pub mod spl_governance {
+    use super::declare_id;
+
+    declare_id!("JPGovTiAUgyqirerBbXXmfyt3SkHVEcpSAPjRCCSHVx");
+}
+
 #[derive(Copy, Clone)]
 pub struct SplGovernance;
 


### PR DESCRIPTION
add `spl_governance` module to export the declared program id

closes #26 