### PR TITLE
GVN-355: Convert ix to use tokens instead of shares

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@jet-lab/jet-engine": "^0.2.32",
+        "@jet-lab/jet-engine": "^0.2.34",
         "@project-serum/anchor": "^0.23.0",
         "@solana/spl-governance": "^0.0.29",
         "@solana/spl-token": "^0.1.8"
@@ -2157,9 +2157,9 @@
       "dev": true
     },
     "node_modules/@jet-lab/jet-engine": {
-      "version": "0.2.32",
-      "resolved": "https://registry.npmjs.org/@jet-lab/jet-engine/-/jet-engine-0.2.32.tgz",
-      "integrity": "sha512-bcJqT5COKGlQP1eypmWtLFDupadOPdADnelR6j6qakd7GWAq7JPF11qmBYPnsyFGOhSMsMPuVbsL9yUQo9YXBQ==",
+      "version": "0.2.34",
+      "resolved": "https://registry.npmjs.org/@jet-lab/jet-engine/-/jet-engine-0.2.34.tgz",
+      "integrity": "sha512-ER9yE2eal16xTb1c/L5A9quI3jxTQnjYq+HlNdRYXU4TlswP/RK61Kn7dE+EIEHHoNOyI1NV/vVv0sIwrk+FSA==",
       "dependencies": {
         "@project-serum/anchor": "^0.21.0",
         "@project-serum/serum": "^0.13.60",
@@ -8822,9 +8822,9 @@
       "dev": true
     },
     "@jet-lab/jet-engine": {
-      "version": "0.2.32",
-      "resolved": "https://registry.npmjs.org/@jet-lab/jet-engine/-/jet-engine-0.2.32.tgz",
-      "integrity": "sha512-bcJqT5COKGlQP1eypmWtLFDupadOPdADnelR6j6qakd7GWAq7JPF11qmBYPnsyFGOhSMsMPuVbsL9yUQo9YXBQ==",
+      "version": "0.2.34",
+      "resolved": "https://registry.npmjs.org/@jet-lab/jet-engine/-/jet-engine-0.2.34.tgz",
+      "integrity": "sha512-ER9yE2eal16xTb1c/L5A9quI3jxTQnjYq+HlNdRYXU4TlswP/RK61Kn7dE+EIEHHoNOyI1NV/vVv0sIwrk+FSA==",
       "requires": {
         "@project-serum/anchor": "^0.21.0",
         "@project-serum/serum": "^0.13.60",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "lint": "eslint app/ --ext ts,tsx"
   },
   "dependencies": {
-    "@jet-lab/jet-engine": "^0.2.32",
+    "@jet-lab/jet-engine": "^0.2.34",
     "@project-serum/anchor": "^0.23.0",
     "@solana/spl-governance": "^0.0.29",
     "@solana/spl-token": "^0.1.8"

--- a/programs/staking/src/instructions/burn_votes.rs
+++ b/programs/staking/src/instructions/burn_votes.rs
@@ -48,12 +48,16 @@ impl<'info> BurnVotes<'info> {
     }
 }
 
-pub fn burn_votes_handler(ctx: Context<BurnVotes>, amount: Option<u64>) -> Result<()> {
+pub fn burn_votes_handler(ctx: Context<BurnVotes>, token_amount: Option<u64>) -> Result<()> {
     let stake_pool = &ctx.accounts.stake_pool;
     let stake_account = &mut ctx.accounts.stake_account;
 
-    let burned_amount = match amount {
-        Some(n) => n,
+    let burned_amount = match token_amount {
+        // If the amount of tokens is specified, convert it to number of shares
+        Some(n) => {
+            let token_pool = stake_pool.bonded.amount();
+            token_pool.with_tokens(Rounding::Up, n).share_amount
+        }
         None => token::accessor::amount(&ctx.accounts.voter_token_account.to_account_info())?,
     };
     stake_account.burn_votes(burned_amount);

--- a/programs/staking/src/instructions/burn_votes.rs
+++ b/programs/staking/src/instructions/burn_votes.rs
@@ -56,7 +56,8 @@ pub fn burn_votes_handler(ctx: Context<BurnVotes>, token_amount: Option<u64>) ->
         // If the amount of tokens is specified, convert it to number of shares
         Some(n) => {
             let token_pool = stake_pool.bonded.amount();
-            token_pool.with_tokens(Rounding::Up, n).share_amount
+            // Round down as we round down when minting, to ensure correct round-trip
+            token_pool.with_tokens(Rounding::Down, n).share_amount
         }
         None => token::accessor::amount(&ctx.accounts.voter_token_account.to_account_info())?,
     };

--- a/programs/staking/src/instructions/unbond_stake.rs
+++ b/programs/staking/src/instructions/unbond_stake.rs
@@ -46,7 +46,7 @@ pub struct UnbondStake<'info> {
 pub fn unbond_stake_handler(
     ctx: Context<UnbondStake>,
     _seed: u32,
-    amount: Option<u64>,
+    token_amount: Option<u64>,
 ) -> Result<()> {
     let stake_pool = &mut ctx.accounts.stake_pool;
     let stake_account = &mut ctx.accounts.stake_account;
@@ -57,7 +57,7 @@ pub fn unbond_stake_handler(
     unbonding_account.unbonded_at = clock.unix_timestamp + stake_pool.unbond_period;
 
     stake_pool.update_vault(ctx.accounts.stake_pool_vault.amount);
-    let unbonded_amount = stake_pool.unbond(stake_account, unbonding_account, amount)?;
+    let unbonded_amount = stake_pool.unbond(stake_account, unbonding_account, token_amount)?;
 
     emit!(StakeUnbonded {
         stake_pool: stake_pool.key(),

--- a/programs/staking/src/state.rs
+++ b/programs/staking/src/state.rs
@@ -178,7 +178,7 @@ pub struct SharedTokenPool {
 /// ensure the tokens/shares are available and not allocated in the program
 /// for any other purpose.
 impl SharedTokenPool {
-    fn amount(&self) -> FullAmount {
+    pub fn amount(&self) -> FullAmount {
         let (tokens, shares) = match self.tokens {
             0 => (INIT_TOKEN_SCALE, INIT_SHARE_SCALE),
             n => (n, self.shares),


### PR DESCRIPTION
The affected ix are:
* burn_votes
* mint_votes

We also renamed a few internal variables (shouldn't break IDL).

We also updated tests, and changed jet-engine to 0.2.34, as x.x.35+ fail to build.