### PR TITLE
New staked jet tooltip

### DIFF
--- a/app/src/components/YourInfo.tsx
+++ b/app/src/components/YourInfo.tsx
@@ -170,7 +170,7 @@ export const YourInfo = () => {
           <Text>
             Staked JET{" "}
             <Tooltip
-              title="For each JET token staked, you may cast 1 vote in JetGovern."
+              title="Staking JET allows you to cast your vote in JetGovern."
               placement="topLeft"
               overlayClassName="no-arrow"
             >


### PR DESCRIPTION
Changed from
> For each JET token staked, you may cast 1 vote in JetGovern.

to

> Staking JET allows you to cast your vote in JetGovern.

![image](https://user-images.githubusercontent.com/3924275/161625160-f523491d-a0a8-44ae-b7da-6055cdc2a50c.png)
