### PR TITLE
GN-358 Reinstated missing styles

### DIFF
--- a/app/src/App.less
+++ b/app/src/App.less
@@ -74,6 +74,19 @@
 
   /* App-specific styling */
   /* This is an extension of the jet-antd library for the purposes of this UI only */
+  .antd-country-phone-input {
+    input {
+      height: 55px;
+    }
+    .ant-select:hover {
+      box-shadow: unset !important;
+    }
+  }
+  .ant-select-dropdown {
+    z-index: 1000;
+    max-width: 265px;
+  }
+
   .column-grid {
     display: grid !important;
     grid-template-columns: repeat(8, 110px);

--- a/app/src/components/Dashboard/StakedJetBalance.tsx
+++ b/app/src/components/Dashboard/StakedJetBalance.tsx
@@ -39,7 +39,7 @@ export const StakedJetBalance = ({
   };
   return (
     <Paragraph
-      className={`text-gradient vote-balance info-legend-item info-legend-item-prefill ${getFontResizeClass(
+      className={`gradient-text vote-balance info-legend-item info-legend-item-prefill ${getFontResizeClass(
         stakedJet.length
       )}`}
       onClick={onClick}

--- a/app/src/components/YourInfo.tsx
+++ b/app/src/components/YourInfo.tsx
@@ -160,7 +160,7 @@ export const YourInfo = () => {
     );
   };
   const canWithdraw = useWithdrawableCount(unbondingAccounts) > 0;
-  
+
   return (
     <div className={`your-info ${isOwnPage ? "view" : ""}`}>
       <Typography>

--- a/app/src/views/Proposal.tsx
+++ b/app/src/views/Proposal.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { ResultProgressBar } from "../components/proposal/ResultProgressBar";
-import { Button, Divider, Popover, Tooltip, Typography } from "antd";
+import { Button, Divider, Popover, Typography } from "antd";
 import { ProposalCard } from "../components/ProposalCard";
 import { VoterList } from "../components/proposal/VoterList";
 import { useWallet } from "@solana/wallet-adapter-react";
@@ -288,7 +288,7 @@ const InnerProposalView = ({
                       </span>
                     </div>
                   }
-                  title="Title"
+                  title="Votes per JET"
                   visible={popoverVisible}
                   trigger="click"
                 >


### PR DESCRIPTION
Some styles were missing after upgrading to the latest `jet-antd` package and some style refactoring. This reintroduces the previous styling.

<details>
<summary>
Before
</summary>

![Screenshot 2022-04-05 at 11 04 02](https://user-images.githubusercontent.com/32130807/161671064-65a0ec61-c88d-45ed-839a-763a7744a583.png)

</details>

<details>
<summary>
After
</summary>

![Screenshot 2022-04-05 at 11 03 37](https://user-images.githubusercontent.com/32130807/161671060-84026517-1562-4574-a65b-6773d0bb9f10.png)

</details>