### PR TITLE
GVN-298 Use tokens instead of shares in yourinfo

### DIFF
--- a/app/src/components/YourInfo.tsx
+++ b/app/src/components/YourInfo.tsx
@@ -160,7 +160,7 @@ export const YourInfo = () => {
     );
   };
   const canWithdraw = useWithdrawableCount(unbondingAccounts) > 0;
-  
+
   return (
     <div className={`your-info ${isOwnPage ? "view" : ""}`}>
       <Typography>
@@ -239,12 +239,12 @@ export const YourInfo = () => {
                       <InfoCircleFilled />
                     </Tooltip>
                   </Text>
-                  <Text>{toTokens(bnToNumber(unbondingQueue), jetMint)}</Text>
+                  <Text>{toTokens(sharesToTokens(unbondingQueue, stakePool).tokens, jetMint)}</Text>
                 </div>
                 <div className="flex justify-between info-legend-item">
                   <Text className="gradient-text bold">Available for Withdrawal</Text>
                   <Text className="gradient-text bold">
-                    {toTokens(bnToNumber(unbondingComplete), jetMint)}
+                    {toTokens(sharesToTokens(unbondingComplete, stakePool).tokens, jetMint)}
                   </Text>
                 </div>
               </>


### PR DESCRIPTION
Implement share to token conversion so that UI displays number of tokens instead of number of shares.

<details>
<summary>Before</summary>

![Screenshot 2022-04-05 at 11 29 24](https://user-images.githubusercontent.com/32130807/161673209-7d105c35-725a-4b85-8055-19d2a746cdd1.png)

</details>

<details>
<summary>After</summary>

![Screenshot 2022-04-05 at 11 29 07](https://user-images.githubusercontent.com/32130807/161673206-7f3d9f4b-0b6b-4e11-bbb9-75e8dbe1a4e5.png)

</details>
