### PR TITLE
staking: export the `PoolConfig` struct from the staking program

### DIFF
--- a/programs/staking/src/lib.rs
+++ b/programs/staking/src/lib.rs
@@ -7,6 +7,7 @@ pub mod events;
 mod instructions;
 pub mod state;
 
+pub use instructions::PoolConfig;
 use instructions::*;
 
 #[program]


### PR DESCRIPTION
closes #46 