### PR TITLE
GVN-363:  Wrong "if" statement caused withdrawal to not be sent, also withdrawAllUnbonded works specifying one account

### DIFF
--- a/app/src/actions/withdrawUnbonded.ts
+++ b/app/src/actions/withdrawUnbonded.ts
@@ -72,7 +72,7 @@ export const withdrawAllUnbonded = async (
       });
     }
   }
-  if (allTxs.length > 0) {
+  if (allTxs.length != 0) {
     await sendAllTransactionsWithNotifications(provider, allTxs, "JET has been withdrawn");
   }
 };

--- a/app/src/actions/withdrawUnbonded.ts
+++ b/app/src/actions/withdrawUnbonded.ts
@@ -72,7 +72,7 @@ export const withdrawAllUnbonded = async (
       });
     }
   }
-  if (allTxs.length != 0) {
+  if (allTxs.length > 0) {
     await sendAllTransactionsWithNotifications(provider, allTxs, "JET has been withdrawn");
   }
 };

--- a/app/src/actions/withdrawUnbonded.ts
+++ b/app/src/actions/withdrawUnbonded.ts
@@ -72,7 +72,7 @@ export const withdrawAllUnbonded = async (
       });
     }
   }
-  if (allTxs.length === 0) {
+  if (allTxs.length != 0) {
     await sendAllTransactionsWithNotifications(provider, allTxs, "JET has been withdrawn");
   }
 };

--- a/app/src/actions/withdrawUnbonded.ts
+++ b/app/src/actions/withdrawUnbonded.ts
@@ -8,12 +8,16 @@ import {
 } from "../tools/transactions";
 import { SendTxRequest } from "@project-serum/anchor/dist/cjs/provider";
 
+/* The instruction creator (UnbondingAccount.withdrawUnbonded) used in this method does not work.  It needs to be fixed
+   before the method can beused.
+ */
 export const withdrawUnbonded = async (
   { connection, wallet, walletPubkey }: RpcContext,
   unbondingAccount: UnbondingAccount,
   stakeAccount: StakeAccount,
   stakePool: StakePool
 ) => {
+  // the below method does not work.
   const instructions = await UnbondingAccount.withdrawUnbonded(
     unbondingAccount,
     stakeAccount,

--- a/app/src/components/modals/VerifyModal.tsx
+++ b/app/src/components/modals/VerifyModal.tsx
@@ -470,7 +470,7 @@ export const VerifyModal = () => {
         continue to browse proposals while disconnected.
       </p>
     ),
-    closable: true
+    closable: false
   };
   steps[Steps.AgreeToTerms] = {
     title: "Warning",

--- a/app/src/components/modals/WithdrawModal.tsx
+++ b/app/src/components/modals/WithdrawModal.tsx
@@ -3,7 +3,7 @@ import { Modal, ModalProps } from "antd";
 import { useRpcContext } from "../../hooks/useRpcContext";
 import { UnbondingAccount } from "@jet-lab/jet-engine";
 import { isSignTransactionError } from "../../utils";
-import {withdrawAllUnbonded, withdrawUnbonded} from "../../actions/withdrawUnbonded";
+import { withdrawAllUnbonded, withdrawUnbonded } from "../../actions/withdrawUnbonded";
 import { useProposalContext } from "../../contexts/proposal";
 
 enum Steps {

--- a/app/src/components/modals/WithdrawModal.tsx
+++ b/app/src/components/modals/WithdrawModal.tsx
@@ -3,7 +3,7 @@ import { Modal, ModalProps } from "antd";
 import { useRpcContext } from "../../hooks/useRpcContext";
 import { UnbondingAccount } from "@jet-lab/jet-engine";
 import { isSignTransactionError } from "../../utils";
-import { withdrawAllUnbonded, withdrawUnbonded } from "../../actions/withdrawUnbonded";
+import { withdrawAllUnbonded } from "../../actions/withdrawUnbonded";
 import { useProposalContext } from "../../contexts/proposal";
 
 enum Steps {

--- a/app/src/components/modals/WithdrawModal.tsx
+++ b/app/src/components/modals/WithdrawModal.tsx
@@ -3,7 +3,7 @@ import { Modal, ModalProps } from "antd";
 import { useRpcContext } from "../../hooks/useRpcContext";
 import { UnbondingAccount } from "@jet-lab/jet-engine";
 import { isSignTransactionError } from "../../utils";
-import { withdrawUnbonded } from "../../actions/withdrawUnbonded";
+import {withdrawAllUnbonded, withdrawUnbonded} from "../../actions/withdrawUnbonded";
 import { useProposalContext } from "../../contexts/proposal";
 
 enum Steps {
@@ -29,7 +29,8 @@ export const WithdrawModal = ({
     }
 
     setLoading(true);
-    withdrawUnbonded(rpcContext, unbondingAccount, stakeAccount, stakePool)
+    let unbondingAccounts: UnbondingAccount[] = [unbondingAccount];
+    withdrawAllUnbonded(rpcContext, unbondingAccounts, stakeAccount, stakePool)
       .then(() => {
         onClose();
       })


### PR DESCRIPTION
i found it by just setting breakpoints all over the place in chrome DevTools. I didn't see the network request going out, found where that should be happening, and worked backwards.

There's something wrong with either what we're supplying to "withdrawUnbonded" or the instruction setter-upper method itself, but I used withdrawAllUnbonded as I saw that it worked for the other change.