### PR TITLE
fix voter weight records not being updated in cancel_unbond

### DIFF
--- a/programs/staking/src/events.rs
+++ b/programs/staking/src/events.rs
@@ -59,6 +59,9 @@ pub struct UnbondCancelled {
 
     pub pool_note: StakePoolNote,
     pub account_note: StakeAccountNote,
+
+    pub voter_weight: u64,
+    pub max_voter_weight: u64,
 }
 
 #[event]

--- a/programs/staking/src/instructions/cancel_unbond.rs
+++ b/programs/staking/src/instructions/cancel_unbond.rs
@@ -17,7 +17,8 @@ pub struct CancelUnbond<'info> {
     /// The account owning the stake to be rebonded
     #[account(mut,
               has_one = owner,
-              has_one = stake_pool)]
+              has_one = stake_pool,
+              has_one = voter_weight_record)]
     pub stake_account: Account<'info, StakeAccount>,
 
     /// The voter weight to be updated
@@ -29,7 +30,9 @@ pub struct CancelUnbond<'info> {
     pub max_voter_weight_record: Box<Account<'info, MaxVoterWeightRecord>>,
 
     /// The stake pool to be rebonded to
-    #[account(mut, has_one = stake_pool_vault)]
+    #[account(mut,
+              has_one = stake_pool_vault,
+              has_one = max_voter_weight_record)]
     pub stake_pool: Account<'info, StakePool>,
 
     /// The stake pool token vault

--- a/programs/staking/src/instructions/cancel_unbond.rs
+++ b/programs/staking/src/instructions/cancel_unbond.rs
@@ -2,6 +2,7 @@ use anchor_lang::prelude::*;
 use anchor_spl::token::TokenAccount;
 
 use crate::events::{Note, UnbondCancelled};
+use crate::spl_addin::{MaxVoterWeightRecord, VoterWeightRecord};
 use crate::state::*;
 
 #[derive(Accounts)]
@@ -18,6 +19,14 @@ pub struct CancelUnbond<'info> {
               has_one = owner,
               has_one = stake_pool)]
     pub stake_account: Account<'info, StakeAccount>,
+
+    /// The voter weight to be updated
+    #[account(mut)]
+    pub voter_weight_record: Box<Account<'info, VoterWeightRecord>>,
+
+    /// The max voter weight
+    #[account(mut)]
+    pub max_voter_weight_record: Box<Account<'info, MaxVoterWeightRecord>>,
 
     /// The stake pool to be rebonded to
     #[account(mut, has_one = stake_pool_vault)]
@@ -37,9 +46,14 @@ pub fn cancel_unbond_handler(ctx: Context<CancelUnbond>) -> Result<()> {
     let stake_pool = &mut ctx.accounts.stake_pool;
     let stake_account = &mut ctx.accounts.stake_account;
     let unbonding_account = &mut ctx.accounts.unbonding_account;
+    let voter_weight = &mut ctx.accounts.voter_weight_record;
+    let max_weight = &mut ctx.accounts.max_voter_weight_record;
 
     stake_pool.update_vault(ctx.accounts.stake_pool_vault.amount);
     let cancelled_amount = stake_pool.rebond(stake_account, unbonding_account);
+
+    stake_account.update_voter_weight_record(voter_weight);
+    stake_pool.update_max_vote_weight_record(max_weight);
 
     emit!(UnbondCancelled {
         stake_pool: stake_pool.key(),

--- a/programs/staking/src/instructions/cancel_unbond.rs
+++ b/programs/staking/src/instructions/cancel_unbond.rs
@@ -68,6 +68,9 @@ pub fn cancel_unbond_handler(ctx: Context<CancelUnbond>) -> Result<()> {
 
         pool_note: stake_pool.note(),
         account_note: stake_account.note(),
+
+        voter_weight: voter_weight.voter_weight,
+        max_voter_weight: max_weight.max_voter_weight,
     });
 
     Ok(())

--- a/tests/airdrop-staking.ts
+++ b/tests/airdrop-staking.ts
@@ -538,6 +538,8 @@ describe("airdrop-staking", () => {
       accounts: {
         owner: staker.publicKey,
         stakeAccount: stakerAccount,
+        voterWeightRecord: stakerVoterWeight,
+        maxVoterWeightRecord: stakeAcc.maxVoterWeightRecord,
         stakePool: stakeAcc.stakePool,
         stakePoolVault: stakeAcc.stakePoolVault,
         unbondingAccount: stakerUnbond,


### PR DESCRIPTION
Canceling unbonds should also readjust the voter weight automatically