### PR TITLE
Show proposal filter by simple majority

### DIFF
--- a/app/src/hooks/proposalHooks.ts
+++ b/app/src/hooks/proposalHooks.ts
@@ -48,9 +48,9 @@ export const getProposalFilters = (
   } else if (proposalFilter === "inactive") {
     return proposals.filter(p => p.account.isVoteFinalized() || p.account.isPreVotingState());
   } else if (proposalFilter === "passed") {
-    return proposals.filter(p => p.account.state === ProposalState.Succeeded);
+    return proposals.filter(p => useIsProposalPassed(p));
   } else if (proposalFilter === "rejected") {
-    return proposals.filter(p => p.account.state === ProposalState.Defeated);
+    return proposals.filter(p => !useIsProposalPassed(p) && !p.account.isPreVotingState());
   } else if (proposalFilter === "all") {
     return proposals;
   } else {
@@ -255,16 +255,6 @@ export function useVoterDisplayData(
         mapper(vr.account.governingTokenOwner, vr.account.getNoVoteWeight()!, VoteOption.No)
       );
 
-    // const abstainVoteData = voteRecords
-    //   .filter(vr => vr.info.getNoVoteWeight()?.gt(ZERO))
-    //   .map(vr =>
-    //     mapper(
-    //       vr.info.governingTokenOwner,
-    //       vr.info.getAbstainVoteWeight()!,
-    //       VoteType.Abstain,
-    //     ),
-    //   );
-
     const data = [...undecidedData, ...yesVoteData, ...noVoteData].sort((a, b) =>
       b.voteWeight.cmp(a.voteWeight)
     );
@@ -300,6 +290,12 @@ export function getVoteCounts(proposal: ProgramAccount<Proposal>) {
     ? 0
     : (bnToNumber(abstain.add(yes)) / bnToNumber(total)) * 100;
   return { yes, no, abstain, total, yesPercent: yesPercent, yesAbstainPercent };
+}
+
+// --------- Check if proposal has passed by simple majority ---------
+export function useIsProposalPassed(proposal: ProgramAccount<Proposal>): boolean {
+  const { yes, no } = getVoteCounts(proposal);
+  return yes.gt(no);
 }
 
 export const useWalletVoteRecords = () => {


### PR DESCRIPTION
## Problem
Currently, the SPL governance program requires a minimum quorum in order for proposals to pass. This becomes difficult to achieve when there are a large number of voters or token accounts, as the vote weight of each account becomes diluted. In the creation of an SPL governance, we are able to select the percentage needed in order for a proposal to succeed, such as 60%.

However, Jet would like to define a passing proposal as a situation in which the number of cast "approve" votes exceeds the number of cast "deny" votes. Proposals would pass by **simple majority of cast votes**, where the number of accounts that have not voted in either direction are inconsequential to the result of a proposal.

This results in two different methods of defining when a proposal is marked as "passed". Consider a situation where 10% of all available accounts by vote weight have voted to approve, and 3% of all available accounts by vote weight have voted to deny. On-chain state would show this proposal as having failed, given a 60% minimum quorum.

Jet would like for this proposal to show as actually having passed, since the absolute vote weight of the approve camp is greater than the deny camp.

## Solution
As we use the SPL governance program, we are constrained by the criteria it uses to define a passing proposal. Since this governance is meant for the purposes of **community signal voting only**, the actual on-chain state of a proposal has no bearing on any critical internal processes or accounts. It is acceptable for us to continue using the SPL governance program in its current implementation.

Our UI will display when a proposal has passed or failed as a matter of simple majority, using a hook to determine if the absolute number of yes votes outweighs the absolute number of no votes. Accounts that have not voted are therefore disregarded for the purposes of determining passing by simple majority.