### PR TITLE
add `serde::Serialize` impls for account structs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,10 +60,10 @@ source = "git+https://github.com/jet-lab/anchor?branch=master#7803acb99574d15dcf
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "regex",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -74,10 +74,10 @@ dependencies = [
  "anchor-syn",
  "anyhow",
  "bs58 0.4.0",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "rustversion",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -86,8 +86,8 @@ version = "0.23.0"
 source = "git+https://github.com/jet-lab/anchor?branch=master#7803acb99574d15dcfde29415c928820fabafbe8"
 dependencies = [
  "anchor-syn",
- "proc-macro2 1.0.36",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -96,9 +96,9 @@ version = "0.23.0"
 source = "git+https://github.com/jet-lab/anchor?branch=master#7803acb99574d15dcfde29415c928820fabafbe8"
 dependencies = [
  "anchor-syn",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -108,9 +108,9 @@ source = "git+https://github.com/jet-lab/anchor?branch=master#7803acb99574d15dcf
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -121,9 +121,9 @@ dependencies = [
  "anchor-syn",
  "anyhow",
  "heck",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -133,9 +133,9 @@ source = "git+https://github.com/jet-lab/anchor?branch=master#7803acb99574d15dcf
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -145,9 +145,9 @@ source = "git+https://github.com/jet-lab/anchor?branch=master#7803acb99574d15dcf
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -173,9 +173,9 @@ source = "git+https://github.com/jet-lab/anchor?branch=master#7803acb99574d15dcf
 dependencies = [
  "anchor-syn",
  "anyhow",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -220,13 +220,13 @@ dependencies = [
  "anyhow",
  "bs58 0.3.1",
  "heck",
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
  "proc-macro2-diagnostics",
- "quote 1.0.17",
+ "quote 1.0.18",
  "serde",
  "serde_json",
  "sha2",
- "syn 1.0.90",
+ "syn 1.0.91",
  "thiserror",
 ]
 
@@ -290,7 +290,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.4.4",
  "object",
  "rustc-demangle",
 ]
@@ -386,8 +386,8 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.36",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -396,9 +396,9 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -407,9 +407,9 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -455,9 +455,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562e382481975bc61d11275ac5e62a19abd00b0547d99516a415336f183dcd0e"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -923,9 +923,9 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "synstructure",
 ]
 
@@ -946,9 +946,9 @@ checksum = "835a3dc7d1ec9e75e2b5fb4ba75396837112d2060b03f7d43bc1897c7f7211da"
 
 [[package]]
 name = "filetime"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -958,14 +958,14 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
 dependencies = [
  "cfg-if",
  "crc32fast",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.5.1",
 ]
 
 [[package]]
@@ -1044,9 +1044,9 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1178,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "hidapi"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "253bfb01a7a31d71212dc3e920540546fa4a4fe08e2d87fc3299c42bae7ee2f9"
+checksum = "38b1717343691998deb81766bfcd1dce6df0d5d6c37070b5a3de2bb6d39f7822"
 dependencies = [
  "cc",
  "libc",
@@ -1252,9 +1252,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
+checksum = "6330e8a36bd8c859f3fa6d9382911fbb7147ec39807f63b923933a247240b9ba"
 
 [[package]]
 name = "httpdate"
@@ -1379,6 +1379,7 @@ name = "jet-proto-auth"
 version = "1.0.0"
 dependencies = [
  "anchor-lang",
+ "serde",
 ]
 
 [[package]]
@@ -1387,10 +1388,10 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eab4c6fd9509fa9c5e6f329363fe47aa77343a5d0b2f82db5a5a2c1e7e3ef6d"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "static_assertions",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1403,6 +1404,7 @@ dependencies = [
  "bytemuck",
  "jet-proto-proc-macros",
  "jet-proto-staking",
+ "serde",
  "static_assertions",
 ]
 
@@ -1413,6 +1415,7 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "jet-proto-auth",
+ "serde",
  "solana-program",
  "spl-governance 2.2.4",
  "spl-governance-addin-api",
@@ -1441,9 +1444,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1477,9 +1480,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.121"
+version = "0.2.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
+checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
 
 [[package]]
 name = "libloading"
@@ -1611,6 +1614,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1661,9 +1673,9 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1711,9 +1723,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
  "proc-macro-crate 1.1.3",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1762,9 +1774,9 @@ checksum = "44a0b52c2cbaef7dffa5fec1a43274afe8bd2a644fa9fc50a9ef4ff0269b1257"
 dependencies = [
  "Inflector",
  "proc-macro-error",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -1889,9 +1901,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "version_check",
 ]
 
@@ -1901,8 +1913,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "version_check",
 ]
 
@@ -1917,9 +1929,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid 0.2.2",
 ]
@@ -1930,9 +1942,9 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "version_check",
  "yansi",
 ]
@@ -1963,11 +1975,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
- "proc-macro2 1.0.36",
+ "proc-macro2 1.0.37",
 ]
 
 [[package]]
@@ -2043,9 +2055,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -2055,14 +2067,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -2301,9 +2312,9 @@ version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -2427,9 +2438,9 @@ dependencies = [
 
 [[package]]
 name = "solana-account-decoder"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b5eac3181f63bcb2f9d20eaaed7eb8866273a848ee79d4ef0727fc0a59f426"
+checksum = "89f862495707ffd5c62445e9ddedf7080cffd5882ef67152c0abc83ca4bd6a37"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -2450,9 +2461,9 @@ dependencies = [
 
 [[package]]
 name = "solana-address-lookup-table-program"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fabf475c4225c562174f04c04111ef0dbb7aa79da23a25029fc570130a255a9"
+checksum = "b90dc285c4497fda6c56bbc2f06215613ddcbac116a1b2a101dbd708815a2485"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -2470,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bloom"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df80d3bdc2a9be76bdcd049657300ad62b4da7132f12252a8f413b64f996b81d"
+checksum = "676596e9b66c299f4748e33ad7e26fb9a874a92daac5cc6dbad32f603375e71a"
 dependencies = [
  "bv",
  "fnv",
@@ -2489,9 +2500,9 @@ dependencies = [
 
 [[package]]
 name = "solana-bucket-map"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668a632d51fea52f46772dc2d4bf239e82b6914e81f2037b08f11ea99cb5b442"
+checksum = "47502f151197bb199762cd43a5acbc4ca9b6beab1f4beec7a436ad55c0feba6c"
 dependencies = [
  "fs_extra",
  "log",
@@ -2506,9 +2517,9 @@ dependencies = [
 
 [[package]]
 name = "solana-clap-utils"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fa6815cd7c814dd30803ba4814b5a6c3435eea5ab9095b7b1c4d0c0d7746f2"
+checksum = "4fc6abbff7fab60dca94e1d70462cd7cd40c7e4b115077f74a4e3f7795f6f34c"
 dependencies = [
  "chrono",
  "clap",
@@ -2524,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "solana-cli-config"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3212b80d572fadd0b08eddcaab8500e1ec8b379a45539498a17a3ec654f94b32"
+checksum = "0db64e96782c0b2bd6f5ff779c2797f0545d14851010b82bec2e8db38d2e9b85"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -2538,9 +2549,9 @@ dependencies = [
 
 [[package]]
 name = "solana-client"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca98b78af855281b51d58f202f56e7129a79e2b95b322c8989ee5689cca1cbab"
+checksum = "53707f90cc8943fd06e4bff6b6a22f68519166f5e7f43bcc736559fdeab8064a"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -2572,9 +2583,9 @@ dependencies = [
 
 [[package]]
 name = "solana-compute-budget-program"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6576c37b7aa0b33180fd3846de6a3b978868f109345c4e1473b76a9b8a64a65"
+checksum = "424553e27234b2a1decb55a5e22fecc66e1cb4e6986254029e9f1f2bdde63e4b"
 dependencies = [
  "solana-program-runtime",
  "solana-sdk",
@@ -2582,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "solana-config-program"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f5936a580565d51bd617915a4ac8ee62b6ed8c82d35d620b977b93b09a4f86e"
+checksum = "eac822fd5d0e1c8e632cb01b513db168689961d5294acc8d40172e7e4beca1c2"
 dependencies = [
  "bincode",
  "chrono",
@@ -2596,9 +2607,9 @@ dependencies = [
 
 [[package]]
 name = "solana-faucet"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc267d7a23fd6cf9a38e0895d77658d519c49cdb0cc340e807a6ca15b6fb3e3"
+checksum = "25e45bc5f5a00569739ea432575995110bcdd188d2d5ad573f926aa9f430e07f"
 dependencies = [
  "bincode",
  "byteorder",
@@ -2619,9 +2630,9 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32bd264fcf01b5e7f6369247a9868164990c3744891901e6657319792ccab29b"
+checksum = "c8db0d37f7c345c6417898e675d218d76a1ce6d3bd57584d7f463d48badf1541"
 dependencies = [
  "bs58 0.4.0",
  "bv",
@@ -2639,21 +2650,21 @@ dependencies = [
 
 [[package]]
 name = "solana-frozen-abi-macro"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e3c82d0b3a69f4cdf9db2959b461d087e1d0044b034eaee547234daafcb776"
+checksum = "023560984c7f16a53e280866c177d1ad45225614356224c1ade671de16424466"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "rustc_version",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
 name = "solana-logger"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5620cd1844bf999141323d434092893b28624a6fef15000265ef372868b153"
+checksum = "57cb0a4ef4dd740397addf5fa50d9dff572371fd47df2bdecc5fb530546490e2"
 dependencies = [
  "env_logger",
  "lazy_static",
@@ -2662,9 +2673,9 @@ dependencies = [
 
 [[package]]
 name = "solana-measure"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0576dd0d57937d8f7fc65a8fa80757b9abfefef32fc30c57a94400d220188692"
+checksum = "8ecdf7b508f87aecd26082d9d05e1e1cc1ffa8ff06351e932c4a7c2bbc8ab994"
 dependencies = [
  "log",
  "solana-sdk",
@@ -2672,9 +2683,9 @@ dependencies = [
 
 [[package]]
 name = "solana-metrics"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a399aeba86cae269b21b27b5940f43b431d802ddfa7e349bc2f7c7c0c12713"
+checksum = "650958e6f07534285108af692b4e93744493ef7ad4e2be4f429813fafcc8050b"
 dependencies = [
  "env_logger",
  "gethostname",
@@ -2686,9 +2697,9 @@ dependencies = [
 
 [[package]]
 name = "solana-net-utils"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3330f04c5bbb620399cb91189d4e0b05bed3600ea7078138bd5bb0c51467571"
+checksum = "bbbf0dd87d791bb3a5ad62dd0f0d99ef14c70080715d918ab38bc0c2dec7aa18"
 dependencies = [
  "bincode",
  "clap",
@@ -2707,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "solana-perf"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db7d246c7709802267284508099491813824ca877cbb1d3d2077c9fb4d059f3"
+checksum = "e978146af727383b616799aa40e7db07c252d3458496cf366c5580be177c1312"
 dependencies = [
  "ahash",
  "bincode",
@@ -2736,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3894d193b164d62525746d9f06cc377d807f282a78c4f2153de69bbed4fef3"
+checksum = "9654224bf5d4c6d80f68c3c996683b389693af1c69103af667c683180bad6c5e"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -2779,9 +2790,9 @@ dependencies = [
 
 [[package]]
 name = "solana-program-runtime"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "429dffedf25c45f7a277c2deea8ebc039a06b07715da544ee01fc9f315a5d9b5"
+checksum = "eda6f25d286b9a62ffc16e28cab1da9a7e90627fe8e1f31f36f1c6b769001473"
 dependencies = [
  "base64 0.13.0",
  "bincode",
@@ -2803,9 +2814,9 @@ dependencies = [
 
 [[package]]
 name = "solana-rayon-threadlimit"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf35b1c40b029494fcb5758cea4e91891be0547193811e8c75cc03ab8e2cb9e"
+checksum = "133433c3e0be762f51f81697750bc6857b4ef6b21d6d7a708ba87181557b7cfa"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -2813,9 +2824,9 @@ dependencies = [
 
 [[package]]
 name = "solana-remote-wallet"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180c4ebee32bc330f006bb78e76076fefa7efdfbf29fbd0af6faf85365fb398d"
+checksum = "221d054daef42cab6819cbbb57b223b6818147dd1944e733fe64a18a2ae359a3"
 dependencies = [
  "base32",
  "console",
@@ -2834,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "solana-runtime"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074dad62b090b34c597cfa0a6d294f79262521362a275182dd012efe4f1cf756"
+checksum = "707ea575126338a2753c7fa8f2a401d0f963fc4481db770fe7c0dc53a81eb6c6"
 dependencies = [
  "arrayref",
  "bincode",
@@ -2889,9 +2900,9 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c292b183ccde17be94eba9f167d2d142df65ef89a99471fb6abdb0d128995848"
+checksum = "eccb410105ddd560ebd8fc463584e0b4e32d2babe374c1e393f18bb58d6404f7"
 dependencies = [
  "assert_matches",
  "base64 0.13.0",
@@ -2940,22 +2951,22 @@ dependencies = [
 
 [[package]]
 name = "solana-sdk-macro"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918b805a36d7c9a82fec5fb8e425539d45cd7e827168b493a5d995ef988a3edf"
+checksum = "bac8cb60eb2e4c85d76ea1f0429dfc0e8b4ba7834e9d69695bb3164f3966e16d"
 dependencies = [
  "bs58 0.4.0",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "rustversion",
- "syn 1.0.90",
+ "syn 1.0.91",
 ]
 
 [[package]]
 name = "solana-stake-program"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c25ab417216af63ed8176c50dc620af56b66af10dedb4ad4b207b02f8f37712"
+checksum = "1a79f35802d328e2887615e33cc50262209ad6d72e878d44a66fd81489afa05c"
 dependencies = [
  "bincode",
  "log",
@@ -2976,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "solana-transaction-status"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b040a594f9c422355a1bfa340621d07b6b2424f7bcee08ed8a22198ecbfe703"
+checksum = "2cd2fbbc13f7607a74bb2df35d953e9cdda5332c4e485bde100b024d7fd48616"
 dependencies = [
  "Inflector",
  "base64 0.12.3",
@@ -3003,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "solana-version"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b22c44602c47edcdbcb63a1088abbbdcc37ce92994e2256ccab0c70a1bb1b5"
+checksum = "42b0bd64ddb6d439de272606944ec092618d1af0efbd850f0340d251e4862ae2"
 dependencies = [
  "log",
  "rustc_version",
@@ -3018,9 +3029,9 @@ dependencies = [
 
 [[package]]
 name = "solana-vote-program"
-version = "1.9.14"
+version = "1.9.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e5b39403e24adcdf0d97b10edc39bfde6cd6967dadd2cb26ef9a58ffc1f0899"
+checksum = "f460173d9d3856cc050c3d1262882883f85b2c61b288364a18be9aadfb15427f"
 dependencies = [
  "bincode",
  "log",
@@ -3197,9 +3208,9 @@ checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -3227,12 +3238,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
  "unicode-xid 0.2.2",
 ]
 
@@ -3242,9 +3253,9 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "unicode-xid 0.2.2",
 ]
 
@@ -3316,9 +3327,9 @@ version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -3391,9 +3402,9 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
@@ -3423,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
 dependencies = [
  "serde",
 ]
@@ -3438,9 +3449,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -3454,16 +3465,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
+checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
 dependencies = [
  "lazy_static",
 ]
@@ -3628,9 +3639,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3638,24 +3649,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
 dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3665,38 +3676,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
 dependencies = [
- "quote 1.0.17",
+ "quote 1.0.18",
  "wasm-bindgen-macro-support",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
 
 [[package]]
 name = "web-sys"
-version = "0.3.56"
+version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3714,9 +3725,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.2"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552ceb903e957524388c4d3475725ff2c8b7960922063af6ce53c9a43da07449"
+checksum = "44d8de8415c823c8abd270ad483c6feeac771fad964890779f9a8cb24fbbc1bf"
 dependencies = [
  "webpki",
 ]
@@ -3843,9 +3854,9 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
- "proc-macro2 1.0.36",
- "quote 1.0.17",
- "syn 1.0.90",
+ "proc-macro2 1.0.37",
+ "quote 1.0.18",
+ "syn 1.0.91",
  "synstructure",
 ]
 

--- a/programs/auth/Cargo.toml
+++ b/programs/auth/Cargo.toml
@@ -16,6 +16,8 @@ no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []
 enforce-authority = []
+cli = ["no-entrypoint", "dep:serde"]
 
 [dependencies]
 anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }
+serde = { version = "1.0", features = ["derive"], optional = true }

--- a/programs/auth/Cargo.toml
+++ b/programs/auth/Cargo.toml
@@ -16,7 +16,7 @@ no-log-ix-name = []
 cpi = ["no-entrypoint"]
 default = []
 enforce-authority = []
-cli = ["no-entrypoint", "dep:serde"]
+cli = ["no-entrypoint", "serde"]
 
 [dependencies]
 anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }

--- a/programs/auth/src/lib.rs
+++ b/programs/auth/src/lib.rs
@@ -15,6 +15,11 @@ mod authority {
 
 #[account]
 #[derive(Debug)]
+#[cfg_attr(
+    feature = "cli",
+    derive(serde::Serialize),
+    serde(rename_all = "camelCase")
+)]
 pub struct UserAuthentication {
     /// The relevant user address
     pub owner: Pubkey,

--- a/programs/rewards/Cargo.toml
+++ b/programs/rewards/Cargo.toml
@@ -14,7 +14,7 @@ no-entrypoint = []
 no-idl = []
 cpi = ["no-entrypoint"]
 default = []
-cli = ["no-entrypoint", "dep:serde"]
+cli = ["no-entrypoint", "serde"]
 
 [dependencies]
 anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }

--- a/programs/rewards/Cargo.toml
+++ b/programs/rewards/Cargo.toml
@@ -14,6 +14,7 @@ no-entrypoint = []
 no-idl = []
 cpi = ["no-entrypoint"]
 default = []
+cli = ["no-entrypoint", "dep:serde"]
 
 [dependencies]
 anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }
@@ -22,4 +23,5 @@ bytemuck = "1.7"
 bitflags = "1.3"
 jet-proto-staking = { path = "../staking", features = ["cpi"] }
 jet-proto-proc-macros = "1"
+serde = { version = "1.0", optional = true }
 static_assertions = "1"

--- a/programs/rewards/src/state/airdrop.rs
+++ b/programs/rewards/src/state/airdrop.rs
@@ -1,4 +1,6 @@
 use anchor_lang::prelude::*;
+#[cfg(feature = "cli")]
+use serde::ser::{Serialize, SerializeStruct, Serializer};
 
 use jet_proto_proc_macros::assert_size;
 
@@ -126,6 +128,43 @@ impl Airdrop {
     }
 }
 
+impl std::fmt::Debug for Airdrop {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("Airdrop")
+            .field("address", &self.address)
+            .field("reward_vault", &self.reward_vault)
+            .field("authority", &self.authority)
+            .field("stake_pool", &self.stake_pool)
+            .field("expire_at", &self.expire_at)
+            .field("flags", &self.flags)
+            .finish()
+    }
+}
+
+#[cfg(feature = "cli")]
+impl Serialize for Airdrop {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_struct("Airdrop", 7)?;
+        s.serialize_field("rewardsVault", &self.reward_vault)?;
+        s.serialize_field("authority", &self.authority)?;
+        s.serialize_field("expireAt", &self.expire_at)?;
+        s.serialize_field("stakePool", &self.stake_pool)?;
+        s.serialize_field("flags", &self.flags)?;
+        s.serialize_field(
+            "shortDescription",
+            &String::from_utf8(self.short_desc.to_vec()).unwrap(),
+        )?;
+        s.serialize_field(
+            "longDescription",
+            &String::from_utf8(self.long_desc.to_vec()).unwrap(),
+        )?;
+        s.end()
+    }
+}
+
 #[repr(C)]
 #[assert_size(400024)]
 #[derive(Clone, Copy)]
@@ -182,18 +221,5 @@ unsafe impl bytemuck::Zeroable for AirdropTargetInfo {}
 
 bitflags::bitflags! {
     pub struct AirdropFlags: u64 {
-    }
-}
-
-impl std::fmt::Debug for Airdrop {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.debug_struct("Airdrop")
-            .field("address", &self.address)
-            .field("reward_vault", &self.reward_vault)
-            .field("authority", &self.authority)
-            .field("stake_pool", &self.stake_pool)
-            .field("expire_at", &self.expire_at)
-            .field("flags", &self.flags)
-            .finish()
     }
 }

--- a/programs/staking/Cargo.toml
+++ b/programs/staking/Cargo.toml
@@ -14,7 +14,7 @@ no-entrypoint = []
 no-idl = []
 cpi = ["no-entrypoint"]
 default = []
-cli = ["no-entrypoint", "dep:serde"]
+cli = ["no-entrypoint", "serde"]
 
 [dependencies]
 anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }

--- a/programs/staking/Cargo.toml
+++ b/programs/staking/Cargo.toml
@@ -14,6 +14,7 @@ no-entrypoint = []
 no-idl = []
 cpi = ["no-entrypoint"]
 default = []
+cli = ["no-entrypoint", "dep:serde"]
 
 [dependencies]
 anchor-lang = { git = "https://github.com/jet-lab/anchor", branch = "master" }
@@ -23,3 +24,4 @@ jet-proto-auth = { path = "../auth", features = ["cpi"] }
 spl-governance = { git = "https://github.com/jet-lab/solana-program-library", branch = "temp-fix-spl-deps", features = ["no-entrypoint"] }
 spl-governance-addin-api = { git = "https://github.com/jet-lab/solana-program-library", branch = "temp-fix-spl-deps" }
 spl-governance-tools = { git = "https://github.com/jet-lab/solana-program-library", branch = "temp-fix-spl-deps" }
+serde = { version = "1.0", features = ["derive"], optional = true }

--- a/programs/staking/src/state.rs
+++ b/programs/staking/src/state.rs
@@ -1,6 +1,7 @@
-use std::convert::TryInto;
-
 use anchor_lang::prelude::*;
+#[cfg(feature = "cli")]
+use serde::ser::{Serialize, SerializeStruct, Serializer};
+use std::convert::TryInto;
 
 use crate::spl_addin::{MaxVoterWeightRecord, VoterWeightAction, VoterWeightRecord};
 use crate::ErrorCode;
@@ -165,10 +166,36 @@ impl StakePool {
     }
 }
 
+#[cfg(feature = "cli")]
+impl Serialize for StakePool {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut s = serializer.serialize_struct("StakePool", 10)?;
+        s.serialize_field("authority", &self.authority)?;
+        s.serialize_field("tokenMint", &self.token_mint)?;
+        s.serialize_field("stakePoolVault", &self.stake_pool_vault)?;
+        s.serialize_field("maxVoterWeightRecord", &self.max_voter_weight_record)?;
+        s.serialize_field("governanceRealm", &self.governance_realm)?;
+        s.serialize_field("stakeCollateralMint", &self.stake_collateral_mint)?;
+        s.serialize_field("unbondPeriod", &self.unbond_period)?;
+        s.serialize_field("vaultAmount", &self.vault_amount)?;
+        s.serialize_field("bonded", &self.bonded)?;
+        s.serialize_field("unbonding", &self.unbonding)?;
+        s.end()
+    }
+}
+
 /// Primitive that represents a pool of tokens with ownership of a portion
 /// of the pool represented by shares. Each SharedTokenPool has a distinct
 /// value for its own shares.
 #[derive(Default, Debug, Copy, Clone, AnchorSerialize, AnchorDeserialize)]
+#[cfg_attr(
+    feature = "cli",
+    derive(serde::Serialize),
+    serde(rename_all = "camelCase")
+)]
 pub struct SharedTokenPool {
     /// Number of tokens held by this pool
     tokens: u64,
@@ -356,6 +383,11 @@ impl FullAmount {
 
 #[account]
 #[derive(Default, Debug)]
+#[cfg_attr(
+    feature = "cli",
+    derive(serde::Serialize),
+    serde(rename_all = "camelCase")
+)]
 pub struct StakeAccount {
     /// The account that has ownership over this stake
     pub owner: Pubkey,
@@ -420,6 +452,11 @@ impl StakeAccount {
 
 #[account]
 #[derive(Default)]
+#[cfg_attr(
+    feature = "cli",
+    derive(serde::Serialize),
+    serde(rename_all = "camelCase")
+)]
 pub struct UnbondingAccount {
     /// The related account requesting to unstake
     pub stake_account: Pubkey,


### PR DESCRIPTION
Adds a new `cli` feature to each of the programs that enables the `serde` crate and accompanying `Serialize` derivations or custom implementations when the `cli` feature is enabled for the program account structs.