### PR TITLE
GVN-406 Show user vote history more descriptively

### DIFF
--- a/app/src/views/Proposal.less
+++ b/app/src/views/Proposal.less
@@ -106,8 +106,8 @@
     }
   }
 
-  .vote-history {
-    padding-left: 10px;
+  .no-pointer svg {
+    cursor: unset;
   }
 }
 

--- a/app/src/views/Proposal.less
+++ b/app/src/views/Proposal.less
@@ -105,6 +105,10 @@
       }
     }
   }
+
+  .vote-history {
+    padding-left: 10px;
+  }
 }
 
 /* Medium devices (tablets, from 840px to 1110px) */

--- a/app/src/views/Proposal.tsx
+++ b/app/src/views/Proposal.tsx
@@ -282,9 +282,8 @@ const InnerProposalView = ({
             {voteRecord && vote !== VoteOption.Undecided && (
               <div>
                 <span>
-                  <HistoryOutlined className="no-pointer" /> You have voted to {
-                      vote === VoteOption.Yes ? "approve" : "reject"
-                    } this proposal.
+                  <HistoryOutlined className="no-pointer" /> You have voted to{" "}
+                  {vote === VoteOption.Yes ? "approve" : "reject"} this proposal.
                 </span>
               </div>
             )}
@@ -348,7 +347,7 @@ const InnerProposalView = ({
                 type="primary"
                 onClick={() => handleVoteModal()}
               >
-                {voteRecord ? "Change Vote": "Vote"}
+                {voteRecord ? "Change Vote" : "Vote"}
               </Button>
               {stakeBalance && loaded && isVoteModalVisible && (
                 <VoteModal

--- a/app/src/views/Proposal.tsx
+++ b/app/src/views/Proposal.tsx
@@ -1,9 +1,14 @@
 import "./Proposal.less";
-import { ArrowLeftOutlined, DownloadOutlined, InfoCircleFilled } from "@ant-design/icons";
+import {
+  ArrowLeftOutlined,
+  DownloadOutlined,
+  InfoCircleFilled,
+  HistoryOutlined
+} from "@ant-design/icons";
 import { bnToNumber, StakeBalance } from "@jet-lab/jet-engine";
 import { Governance, ProgramAccount, Proposal, ProposalState, Realm } from "@solana/spl-governance";
 import { useWallet } from "@solana/wallet-adapter-react";
-import { Button, Divider, Popover, Typography } from "antd";
+import { Button, Divider, Popover, Tooltip, Typography } from "antd";
 import { useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Link } from "react-router-dom";
@@ -205,7 +210,21 @@ const InnerProposalView = ({
             </Text>
 
             {/* Proposal Title */}
-            <Title className="description-title">{loaded ? proposal.account.name : "---"}</Title>
+            <Title className="description-title">
+              {loaded ? proposal.account.name : "---"}
+              {/* Info about user's vote history */}
+              {voteRecord && vote !== VoteOption.Undecided && (
+                <Tooltip
+                  title={`You have voted ${
+                    vote === VoteOption.Yes ? "to approve" : "to reject"
+                  } this proposal.`}
+                  placement="topLeft"
+                  overlayClassName="no-arrow"
+                >
+                  <HistoryOutlined className="vote-history" />
+                </Tooltip>
+              )}
+            </Title>
 
             {/* Main Proposal Content */}
             {gistInfo && <RenderContent proposal={proposal} gistInfo={gistInfo} />}

--- a/app/src/views/Proposal.tsx
+++ b/app/src/views/Proposal.tsx
@@ -8,7 +8,7 @@ import {
 import { bnToNumber, StakeBalance } from "@jet-lab/jet-engine";
 import { Governance, ProgramAccount, Proposal, ProposalState, Realm } from "@solana/spl-governance";
 import { useWallet } from "@solana/wallet-adapter-react";
-import { Button, Divider, Popover, Tooltip, Typography } from "antd";
+import { Button, Divider, Popover, Typography } from "antd";
 import { useEffect, useMemo, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { Link } from "react-router-dom";
@@ -210,21 +210,7 @@ const InnerProposalView = ({
             </Text>
 
             {/* Proposal Title */}
-            <Title className="description-title">
-              {loaded ? proposal.account.name : "---"}
-              {/* Info about user's vote history */}
-              {voteRecord && vote !== VoteOption.Undecided && (
-                <Tooltip
-                  title={`You have voted ${
-                    vote === VoteOption.Yes ? "to approve" : "to reject"
-                  } this proposal.`}
-                  placement="topLeft"
-                  overlayClassName="no-arrow"
-                >
-                  <HistoryOutlined className="vote-history" />
-                </Tooltip>
-              )}
-            </Title>
+            <Title className="description-title">{loaded ? proposal.account.name : "---"}</Title>
 
             {/* Main Proposal Content */}
             {gistInfo && <RenderContent proposal={proposal} gistInfo={gistInfo} />}
@@ -292,6 +278,16 @@ const InnerProposalView = ({
               </div>
             </div>
 
+            {/* Info about user's vote history */}
+            {voteRecord && vote !== VoteOption.Undecided && (
+              <div>
+                <span>
+                  <HistoryOutlined className="no-pointer" /> You have voted to {
+                      vote === VoteOption.Yes ? "approve" : "reject"
+                    } this proposal.
+                </span>
+              </div>
+            )}
             <div>
               <span>
                 Votes per JET{" "}
@@ -352,7 +348,7 @@ const InnerProposalView = ({
                 type="primary"
                 onClick={() => handleVoteModal()}
               >
-                Vote
+                {voteRecord ? "Change Vote": "Vote"}
               </Button>
               {stakeBalance && loaded && isVoteModalVisible && (
                 <VoteModal


### PR DESCRIPTION
- Show user's vote, if any, as history verbiage below results bars.
- Show "change vote" instead of just "vote" if user already has an existing vote.

This makes it more obvious that the user has already voted on any given proposal.

<img width="522" alt="Screenshot 2022-05-31 at 15 19 35" src="https://user-images.githubusercontent.com/32130807/171203048-23d7e5eb-ee58-49fc-b3ff-ca9b2a260984.png">
<img width="291" alt="Screenshot 2022-05-31 at 15 19 46" src="https://user-images.githubusercontent.com/32130807/171203065-d60053a0-8ae3-46bd-b612-5d45b448eb80.png">

